### PR TITLE
Add Graphical Expression of Materials Data (GEMD) to standardization initiatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Contributions are very welcome - please follow the [guidelines](CONTRIBUTING.md)
 - [NOMAD Meta Info](https://metainfo.nomad-coe.eu/nomadmetainfo_public/archive.html) - Schema for storing results of ab initio and force-field atomistic simulations (by NOMAD Laboratory).
 - [OPTIMADE](https://www.optimade.org) - Open Databases Integration for Materials Design, a REST API standard for exchanging materials information.
 - [PIF](https://citrineinformatics.github.io/pif-documentation/index.html) - Physical Information File schema (by Citrine).
+- [GEMD](https://citrineinformatics.github.io/gemd-docs/) - Graphical Expression of Materials Data (by Citrine) -- supersedes PIF.
 - [Semantic Assets for Materials Science](https://doi.org/10.5281/zenodo.2456346) - Task group within the [vocabulary services interest group](https://rd-alliance.org/groups/vocabulary-services-interest-group.html) of the Research Data Alliance.
 - [SMIRNOFF](https://open-forcefield-toolkit.readthedocs.io/en/latest/smirnoff.html) - Specification for encoding molecular mechanics force fields (by [Open Force Field Initiative](http://openforcefield.org/)).
 


### PR DESCRIPTION
From the [documentation](https://citrineinformatics.github.io/gemd-docs/):

> [GEMD] links together materials, the processes that produced them, and the measurements that characterize them. This facilitates the backwards traversal from a measurement to the material on which it was performed to the process by which it was produced to the materials which were used in that process. It generalizes and matures preparation and subSystems objects within the PIF (Physical Information File).

> Additionally, the model makes a first-class distinction between intent and realization, captured by Spec and Run objects, respectively. A single intent Spec can be realized into multiple Run objects. This generalizes and matures the ideal concept from the PIF's Composition and Quantity objects.

> The model contains a new type of object: the Measurement Run. Measurements capture discrete measurement activity, including the parameters and conditions associated with a set of measured properties. This many-to-many relationship between properties, conditions, and parameters resolves a fundamental ambiguity present in the PIF; which properties were measured at the same time under the same conditions?