### PR TITLE
Add link to aviary.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Contributions are very welcome - please follow the [guidelines](CONTRIBUTING.md)
 - [ASE](https://wiki.fysik.dtu.dk/ase) - Atomic Simulation Environment (**Python**).
 - [ASR](https://gitlab.com/dtorel/asr) - Atomic Simulation Recipes, based on ASE (**Python**).
 - [atomate](https://hackingmaterials.github.io/atomate) - Materials science workflows based on FireWorks, developed at LBNL (**Python**). [![Github Stars](https://img.shields.io/github/stars/hackingmaterials/atomate?style=social)](https://github.com/hackingmaterials/atomate) 
+- [aviary](https://github.com/CompRhys/aviary) - Predict materials properties using compositions, Wyckoff representations, and crystal structures (**Python**). [![Github Stars](https://img.shields.io/github/stars/CompRhys/aviary?style=social)](https://github.com/CompRhys/aviary)
 - [BIOVIA Materials Studio](https://www.3ds.com/products-services/biovia/products/molecular-modeling-simulation/biovia-materials-studio/) - _Proprietary_ simulation infrastructure.
 - [CAMD](https://github.com/tri-amdd/camd) - Agent-based sequential learning software for materials discovery (**Python**). [![Github Stars](https://img.shields.io/github/stars/tri-amdd/camd?style=social)](https://github.com//tri-amdd/camd)
 - [CrabNet](https://github.com/anthony-wang/CrabNet) - Predict materials properties using only the composition information. (**Python**). ![GitHub Repo stars](https://img.shields.io/github/stars/anthony-wang/CrabNet?style=social)


### PR DESCRIPTION
Add link to aviary which contains implementations of `roost`, `wren`, and `cgccn`. Can also add link to original `roost` repo but it's been deprecated in favour of `aviary` so would rather point to maintained repo despite `roost` being more popular at present.

`roost` - https://www.nature.com/articles/s41467-020-19964-7
`wren` - https://arxiv.org/abs/2106.11132 